### PR TITLE
Add basic stack support

### DIFF
--- a/localfs.js
+++ b/localfs.js
@@ -160,7 +160,7 @@ function checkExistingProjects (driver, projects) {
             if (!err) {
                 if (!results[0]) {
                     // let projectOpts = JSON.parse(project.options)
-                    logger.info(`Restarting project ${project.id}}`)
+                    logger.info(`Restarting project ${project.id}`)
                     const pid = await startProject(driver._app, project, {}, projectSettings.path, projectSettings.port)
 
                     await project.updateSetting('pid', pid)

--- a/localfs.js
+++ b/localfs.js
@@ -90,7 +90,6 @@ async function startProject (app, project, options, userDir, port) {
      *              location using a set of instructions we provide (to be written)
      */
 
-
     logger.debug(`Project Environment Vars ${JSON.stringify(env)}`)
 
     const out = fs.openSync(path.join(userDir, '/out.log'), 'a')


### PR DESCRIPTION
A localfs stack consists of two properties:
 - memory
 - nodered

This PR adds the necessary meta data to the object returned by `init` to tell the runtime about these two stack properties.

`memory` gets passed to the launcher via the `/settings` end-point - so the driver doesn't need to anything with it.

`nodered` identifies the version of NR to use. The assumption is the admin will have to manually install that version of Node-RED to a well known location that the driver can use when starting the launcher.

The validation regex for the nodered version string supports:
 - `1.2.3`
 - `1.2`
 - `1`
 - `1.x`
 - `1.*`
 - `1.2.x`
 - `1.2.*`

But I'm happy to be told that is a ridiculous amount of flexibility for day one and the regex should be changed to just cope with `1.2.3`