### PR TITLE
Add support to load different Node-RED Versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,15 @@ The following environment variables (in the `.env` file) configure this driver
  - LOCALFS_ROOT=<path/to/store/project/userDirs>
  - LOCALFS_START_PORT=7880
  - LOCALFS_NODE_PATH=<path/to/node/binary> (not required, but useful with nvm)
+
+## Node-RED Versions for Stacks
+
+To install copies of different versions of Node-RED for use by Project Stacks do the following:
+
+Assuming you wish to install Node-RED v2.2.2
+
+- In the `var` directory create a directory called `stacks`
+- In the `var/stacks` directory create a directory called `2.2.2`
+- in the `var/stacks/2.2.2` directory run `npm install --prefix . node-red@2.2.2`
+
+In the FlowForge Admin settings create a Stack with the Node-RED version `2.2.2`

--- a/localfs.js
+++ b/localfs.js
@@ -89,8 +89,9 @@ async function startProject (app, project, options, userDir, port) {
      *              version of Node-RED. We assume the admin has installed it to a well-known
      *              location using a set of instructions we provide (to be written)
      */
-
-
+    if (project.ProjectStack?.properties.nodered) {
+        env.FORGE_NR_PATH = path.resolve(app.config.home, 'var/stacks', project.ProjectStack.properties.nodered)
+    }
     logger.debug(`Project Environment Vars ${JSON.stringify(env)}`)
 
     const out = fs.openSync(path.join(userDir, '/out.log'), 'a')


### PR DESCRIPTION
Pass the location of Node-RED version from stack to https://github.com/flowforge/flowforge-nr-launcher