### PR TITLE
Move setting project URL to before launcher started

### DIFF
--- a/localfs.js
+++ b/localfs.js
@@ -300,6 +300,11 @@ module.exports = {
             port: port
         })
 
+        const baseURL = new URL(this._app.config.base_url)
+        baseURL.port = port
+        project.url = baseURL.href
+        await project.save()
+
         // Kick-off the project start and return the promise to let it
         // complete asynchronously
         return startProject(this._app, project, project.ProjectStack, directory, port).then(async pid => {
@@ -310,10 +315,6 @@ module.exports = {
                 setTimeout(async () => {
                     logger.debug(`PID ${pid}, port, ${port}, directory, ${directory}`)
                     await project.updateSetting('pid', pid)
-                    const baseURL = new URL(this._app.config.base_url)
-                    baseURL.port = port
-                    project.url = baseURL.href
-                    await project.save()
                     this._projects[project.id].state = 'started'
                     resolve()
                 }, 1000)


### PR DESCRIPTION
There is comment about a race condition, but this settings the url after starting the project adds a new race condition where
the laucher asks for the project settings before the URL is set causing a failure to start.

This moves the setting of the URL to before the 1 second delay and before the flowforge-nr-launcher is started.