### PR TITLE
Modify nodered stack property regex to support beta releases

### DIFF
--- a/localfs.js
+++ b/localfs.js
@@ -255,17 +255,18 @@ module.exports = {
         this._checkInterval = setInterval(() => {
             checkExistingProjects(this)
         }, 60000)
-
         return {
             stack: {
                 properties: {
                     nodered: {
                         label: 'Node-RED Version',
-                        validate: '^(0|[1-9]\\d*)(\\.(0|[1-9]\\d*|x|\\*)(\\.(0|[1-9]\\d*|x|\\*))?)?$',
+                        description: 'This must match a version installed on the platform. See the docs for how to setup stacks locally.',
+                        validate: '^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(-.*)?$',
                         invalidMessage: 'Invalid version number - expected x.y.z'
                     },
                     memory: {
                         label: 'Memory (MB)',
+                        description: 'This is the point at which the runtime will start garbage collecting unused memory. It is not a hard limit.',
                         validate: '^[1-9]\\d*$',
                         invalidMessage: 'Invalid value - must be a number'
                     }


### PR DESCRIPTION
Fixes #42 

The previous regex was quite flexible in allowing things like:

 - `2`
 - `2.*`
 - `2.x`
 - `2.2.x`
 - `2.2.2`

However it really needs to be the fully qualified version string - not something with wildcards. It also didn't allow the `x.y.z-meta` style version strings.

This PR tightens it up to require a strict `x.y.z` with an optional `-meta` component.

It also adds a description field to the properties that will be displayed in the UI thanks to https://github.com/flowforge/flowforge/pull/565

