### PR TITLE
Add description to stack memory value

### DIFF
--- a/localfs.js
+++ b/localfs.js
@@ -266,8 +266,9 @@ module.exports = {
                     },
                     memory: {
                         label: 'Memory (MB)',
-                        validate: '^[1-9]\\d*$',
-                        invalidMessage: 'Invalid value - must be a number'
+                        validate: '^[1-9]\\d+$',
+                        invalidMessage: 'Invalid value - must be a number',
+                        description: 'NodeJS --max-old-space, recomended minimum 256'
                     }
                 }
             }


### PR DESCRIPTION
Also edit regex to enforce at least 2 digits as 1-9mb will never be right.

Part of fix for https://github.com/flowforge/flowforge/issues/583