### PR TITLE
Map FlowForge logout to nodered auth/revoke

### DIFF
--- a/localfs.js
+++ b/localfs.js
@@ -434,6 +434,25 @@ module.exports = {
             }
         })
     },
+    /**
+   * Logout Node-RED instance
+   * @param {Project} project - the project model instance
+   * @param {string} token - the node-red token to revoke
+   * @return {forge.Status}
+   */
+    logoutNodeRED: async (project, token) => { // logout:nodered(step-3)
+        const port = await project.getSetting('port')
+        try {
+            await got.post('http://localhost:' + (port + 1000) + '/flowforge/command', { // logout:nodered(step-4)
+                json: {
+                    cmd: 'logout',
+                    token: token
+                }
+            })
+        } catch (error) {
+            console.error(error)
+        }
+    },
 
     /**
    * Get a Project's logs


### PR DESCRIPTION
fixes https://github.com/flowforge/flowforge/issues/442

## NOTE
NOTE: this PR is to be reviewed and merged as 1 of 3 parts. 

1. UPDATE ME WHEN ALL PRs RAISED
1. UPDATE ME WHEN ALL PRs RAISED
1. UPDATE ME WHEN ALL PRs RAISED

## Changes
* Refer to UPDATE ME WHEN ALL PRs RAISED for steps 1~3 in this process
* Adds `logoutNodeRED` in `localfs.js` (STEP 3) 
  * Gets the projects PORT and calls to the endpoint `/flowforge/command'` with command `logout`
* Refer to UPDATE ME WHEN ALL PRs RAISED for remaining steps in this process
