### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
     "license": "Apache-2.0",
     "dependencies": {
         "@flowforge/nr-launcher": "^0.5.0",
-        "got": "^11.8.3",
-        "sequelize": "^6.9.0"
+        "got": "^11.8.5"
     },
     "devDependencies": {
         "eslint": "^7.32.0",


### PR DESCRIPTION
Tidy up npm dependencies.

Sequelize was no longer a used dependency in the driver.