### PR TITLE
Prevent localfs crash when deleting project

### DIFF
--- a/localfs.js
+++ b/localfs.js
@@ -357,8 +357,12 @@ module.exports = {
         const projectSettings = await project.getAllSettings()
         stopProject(this._app, project, projectSettings)
 
-        setTimeout(() => {
-            fs.rm(projectSettings.path, { recursive: true, force: true })
+        setTimeout(async () => {
+            try {
+                await fs.rm(projectSettings.path, { recursive: true, force: true })
+            } catch (error) {
+                logger.warn(`Error removing project files: ${projectSettings.path}`)
+            }
         }, 5000)
 
         this._usedPorts.delete(projectSettings.port)


### PR DESCRIPTION
Issue noticed by myself and Ben while debugging new work last week.

Essentially, 
* wrap the `fs.rm` with try catch to prevent launcher crash if files cannot be deleted
* log a warning

