### PR TITLE
Introduce publish pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   build:
+    if: false
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,8 +22,6 @@ jobs:
       contents: read
       packages: write
     steps:
-      - name: debug payload
-        run: echo ${{ github.event.client_payload.nr_launcher_release_name }}
       - name: Checkout
         uses: actions/checkout@v3
       - name: Set nigthly release
@@ -41,3 +39,17 @@ jobs:
           package: ./package.json
           registry: https://npm.pkg.github.com
           token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Generate a token
+        id: generate_token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.GH_BOT_APP_ID }}
+          private_key: ${{ secrets.GH_BOT_APP_KEY }}
+      - name: Trigger flowforge package rebuild
+        uses: benc-uk/workflow-dispatch@v1
+        with:
+          workflow: publish.yml
+          repo: flowforge/flowforge
+          ref: feat-publish-pipeline-poc
+          token: ${{ steps.generate_token.outputs.token }}
+          inputs: '{"localfs_ref": "${{ github.ref }}", "localfs_release_name": "${{ env.release_name }}"}'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ on:
     - cron: '0 23 * * *'
   push:
     branches:
-      - 'feat-' 
+      - 'feat-*' 
 
 jobs:
   publish:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,8 @@
 name: Publish
 on:
+  repository_dispatch:
+    types: 
+      - nr-launcher-trigger
   schedule:
     - cron: '0 23 * * *'
   push:
@@ -13,6 +16,8 @@ jobs:
       contents: read
       packages: write
     steps:
+      - name: debug payload
+        run: echo ${{ github.event.client_payload.nr_launcher_release_name }}
       - name: Checkout
         uses: actions/checkout@v3
       - name: Set nigthly release

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set nigthly release
         id: set_release
         # if: ${{ github.event_name == 'schedule' }}
-        run: echo "release_name=nightly" >> $GITHUB_ENV
+        run: echo "release_name=nightly" >> $GITHUB_OUTPUT
   
   publish:
     needs: prepare

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,40 @@
+name: Publish
+on:
+  schedule:
+    - cron: '0 23 * * *'
+  push:
+    branches:
+      - 'feature/*' 
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set nigthly release
+        # if: ${{ github.event_name == 'schedule' }}
+        run: echo "release_name=nightly" >> $GITHUB_ENV
+      - name: "Set versions"
+        run: |
+          npm version prerelease --preid `git rev-parse --short HEAD`-`date +%Y%m%d` --no-git-tag-version
+          cat package.json | jq '.dependencies["@flowforge/nr-launcher"] = "${{ env.release_name }}"' > package.json-patched
+          mv package.json-patched package.json
+      - name: "Publish flowforge-nr-launcher"
+        uses: JS-DevTools/npm-publish@v2
+        with:
+          tag: ${{ env.release_name }}
+          package: ./package.json
+          registry: https://npm.pkg.github.com
+          token: ${{ secrets.GITHUB_TOKEN }}  
+      - name: "Publish flowforge-nr-theme"
+        uses: JS-DevTools/npm-publish@v2
+        with:
+          tag: ${{ env.release_name }}
+          package: ./lib/theme/package.json
+          ignore-scripts: false
+          registry: https://npm.pkg.github.com
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,33 +18,27 @@ on:
 
 
 jobs:
-  # prepare:
-  #   runs-on: ubuntu-latest
-  #   outputs:
-  #     release_name: ${{ steps.set_release.outputs.release_name }}
-  #   steps:
-  #     - name: Set nigthly release
-  #       id: set_release
-  #       # if: ${{ github.event_name == 'schedule' }}
-  #       run: echo "release_name=nightly" >> $GITHUB_OUTPUT
-  
-  publish:
-    # needs: prepare
+  prepare:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
+    outputs:
+      release_name: ${{ steps.set_release.outputs.release_name }}
     steps:
       - name: Set nigthly release
         id: set_release
         # if: ${{ github.event_name == 'schedule' }}
         run: echo "release_name=nightly" >> $GITHUB_OUTPUT
-      - uses: 'flowforge/github-actions-workflows/.github/workflows/publish_node_package.yml@feat-npm-publish-workflow'
-        with:
-          release_name: ${{ needs.prepare.outputs.release_name}}
-          package_name: flowforge-driver-localfs
-          package_dependencies: |
-            @flowforge/nr-launcher
+  
+  publish:
+    needs: prepare
+    permissions:
+      contents: read
+      packages: write
+    uses: 'flowforge/github-actions-workflows/.github/workflows/publish_node_package.yml@feat-npm-publish-workflow'
+    with:
+      release_name: ${{ needs.prepare.outputs.release_name}}
+      package_name: flowforge-driver-localfs
+      package_dependencies: |
+        @flowforge/nr-launcher
         
   dispatch:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set nigthly release
         # if: ${{ github.event_name == 'schedule' }}
         run: echo "release_name=nightly" >> $GITHUB_ENV
-      - name: "Set versions"
+      - name: "Set dependecies versions"
         run: |
           npm version prerelease --preid `git rev-parse --short HEAD`-`date +%Y%m%d` --no-git-tag-version
           cat package.json | jq '.dependencies["@flowforge/nr-launcher"] = "${{ env.release_name }}"' > package.json-patched

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,14 +28,6 @@ jobs:
       package_name: flowforge-driver-localfs
       package_dependencies: |
         @flowforge/nr-launcher
-  
-  debug:
-    runs-on: ubuntu-latest
-    needs: package
-    steps:
-      - name: Print release name from package job
-        run: echo ${{ needs.package.outputs.release_name }}
-
 
   dispatch:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,9 @@ on:
         required: false
   schedule:
     - cron: '0 23 * * *'
+  pull_request:
+    branches: 
+      - main
   push:
     branches:
       - 'feat-*'
@@ -19,7 +22,10 @@ on:
 
 
 jobs:
-  package:
+  build:
+    uses: 'flowforge/github-actions-workflows/.github/workflows/build_node_package.yml@main'
+
+  publish:
     permissions:
       contents: read
       packages: write
@@ -31,7 +37,7 @@ jobs:
 
   dispatch:
     runs-on: ubuntu-latest
-    needs: package
+    needs: publish
     if: false
     steps:
       - name: Generate a token

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,6 @@ on:
     branches:
       - 'feat-*' 
 
-
 jobs:
   prepare:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,7 @@ on:
     branches:
       - 'feat-*' 
 
+
 jobs:
   prepare:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,28 +24,28 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
       - name: Set nigthly release
         # if: ${{ github.event_name == 'schedule' }}
         run: echo "release_name=nightly" >> $GITHUB_ENV
-      - name: "Set dependecies versions"
-        run: |
-          npm version prerelease --preid `git rev-parse --short HEAD`-`date +%Y%m%d` --no-git-tag-version
-          cat package.json | jq '.dependencies["@flowforge/nr-launcher"] = "${{ env.release_name }}"' > package.json-patched
-          mv package.json-patched package.json
-      - name: "publish flowforge-driver-localfs"
-        uses: JS-DevTools/npm-publish@v2
+
+      - name: Build and publish package
+        uses: flowforge/github-actions-workflows/.github/workflows/publish_node_package.yml@feat-npm-publish-workflow
         with:
-          tag: ${{ env.release_name }}
-          package: ./package.json
-          registry: https://npm.pkg.github.com
-          token: ${{ secrets.GITHUB_TOKEN }}
+          release_name: ${{ env.release_name }}
+          package_name: flowforge-driver-localfs
+          package_dependencies: |
+            @flowforge/nr-launcher
+
       - name: Generate a token
         id: generate_token
         uses: tibdex/github-app-token@v1
         with:
           app_id: ${{ secrets.GH_BOT_APP_ID }}
           private_key: ${{ secrets.GH_BOT_APP_KEY }}
+
       - name: Trigger flowforge package rebuild
+        if: false
         uses: benc-uk/workflow-dispatch@v1
         with:
           workflow: publish.yml

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-    uses: 'flowforge/github-actions-workflows/.github/workflows/publish_node_package.yml@feat-npm-publish-outputs'
+    uses: 'flowforge/github-actions-workflows/.github/workflows/publish_node_package.yml@main'
     with:
       package_name: flowforge-driver-localfs
       package_dependencies: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,7 @@ jobs:
     uses: 'flowforge/github-actions-workflows/.github/workflows/publish_node_package.yml@main'
     with:
       package_name: flowforge-driver-localfs
-      publish_package: true\
+      publish_package: true
       package_dependencies: |
         @flowforge/nr-launcher
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,3 +56,4 @@ jobs:
           ref: feat-publish-pipeline-poc
           token: ${{ steps.generate_token.outputs.token }}
           inputs: '{"localfs_ref": "${{ github.ref }}", "localfs_release_name": "${{ needs.package.outputs.release_name }}"}'
+          

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ on:
     branches:
       - 'feat-*' 
 
-      
+
 jobs:
   prepare:
     runs-on: ubuntu-latest
@@ -29,6 +29,7 @@ jobs:
         run: echo "release_name=nightly" >> $GITHUB_ENV
   
   publish:
+    needs: prepare
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,11 @@
 name: Publish
 on:
-  repository_dispatch:
-    types: 
-      - nr-launcher-trigger
+  workflow_dispatch:
+    inputs:
+      nr_launcher_release_name:
+        description: 'flowforge-nr-launcher package version'
+        required: false
+        default: 'nightly'
   schedule:
     - cron: '0 23 * * *'
   push:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,7 @@ on:
     branches:
       - 'feat-*' 
 
+      
 jobs:
   prepare:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,24 +17,23 @@ on:
       - 'feat-*' 
 
 jobs:
-  prepare:
-    runs-on: ubuntu-latest
-    outputs:
-      release_name: ${{ steps.set_release.outputs.release_name }}
-    steps:
-      - name: Set nigthly release
-        id: set_release
-        # if: ${{ github.event_name == 'schedule' }}
-        run: echo "release_name=nightly" >> $GITHUB_OUTPUT
+    # prepare:
+    # runs-on: ubuntu-latest
+    # outputs:
+    #   release_name: ${{ steps.set_release.outputs.release_name }}
+    # steps:
+    #   - name: Set nigthly release
+    #     id: set_release
+    #     if: ${{ github.event_name == 'schedule' }}
+    # run: echo "release_name=nightly" >> $GITHUB_OUTPUT
   
-  publish:
-    needs: prepare
+  package:
     permissions:
       contents: read
       packages: write
     uses: 'flowforge/github-actions-workflows/.github/workflows/publish_node_package.yml@feat-npm-publish-workflow'
     with:
-      release_name: ${{ needs.prepare.outputs.release_name}}
+      # release_name: ${{ needs.prepare.outputs.release_name}}
       package_name: flowforge-driver-localfs
       package_dependencies: |
         @flowforge/nr-launcher

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,8 +17,7 @@ on:
       - main
   push:
     branches:
-      - 'feat-*'
-      - 'main'
+      - main
 
 
 jobs:
@@ -26,6 +25,7 @@ jobs:
     uses: 'flowforge/github-actions-workflows/.github/workflows/build_node_package.yml@main'
 
   publish:
+    needs: build
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,7 @@ on:
     branches:
       - 'feat-*' 
 
+
 jobs:
     # prepare:
     # runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,6 +36,7 @@ jobs:
       - name: Print release name from package job
         run: echo ${{ needs.package.outputs.release_name }}
 
+
   dispatch:
     runs-on: ubuntu-latest
     needs: package

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,5 @@
-name: Publish
+name: Build and push package
+
 on:
   workflow_dispatch:
     inputs:
@@ -16,27 +17,31 @@ on:
       - 'feat-*' 
 
 jobs:
-  publish:
+  prepare:
     runs-on: ubuntu-latest
+    outputs:
+      release_name: ${{ steps.set_release.outputs.release_name }}
+    steps:
+      - name: Set nigthly release
+        id: set_release
+        # if: ${{ github.event_name == 'schedule' }}
+        run: echo "release_name=nightly" >> $GITHUB_ENV
+  
+  publish:
     permissions:
       contents: read
       packages: write
+    uses: 'flowforge/github-actions-workflows/.github/workflows/publish_node_package.yml@feat-npm-publish-workflow'
+    with:
+      release_name: ${{ needs.prepare.outputs.release_name}}
+      package_name: flowforge-driver-localfs
+      package_dependencies: |
+        @flowforge/nr-launcher
+        
+  dispatch:
+    runs-on: ubuntu-latest
+    if: false
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Set nigthly release
-        # if: ${{ github.event_name == 'schedule' }}
-        run: echo "release_name=nightly" >> $GITHUB_ENV
-
-      - name: Build and publish package
-        uses: flowforge/github-actions-workflows/.github/workflows/publish_node_package.yml@feat-npm-publish-workflow
-        with:
-          release_name: ${{ env.release_name }}
-          package_name: flowforge-driver-localfs
-          package_dependencies: |
-            @flowforge/nr-launcher
-
       - name: Generate a token
         id: generate_token
         uses: tibdex/github-app-token@v1
@@ -45,7 +50,6 @@ jobs:
           private_key: ${{ secrets.GH_BOT_APP_KEY }}
 
       - name: Trigger flowforge package rebuild
-        if: false
         uses: benc-uk/workflow-dispatch@v1
         with:
           workflow: publish.yml

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,33 +14,31 @@ on:
     - cron: '0 23 * * *'
   push:
     branches:
-      - 'feat-*' 
+      - 'feat-*'
+      - 'main'
 
 
 jobs:
-    # prepare:
-    # runs-on: ubuntu-latest
-    # outputs:
-    #   release_name: ${{ steps.set_release.outputs.release_name }}
-    # steps:
-    #   - name: Set nigthly release
-    #     id: set_release
-    #     if: ${{ github.event_name == 'schedule' }}
-    # run: echo "release_name=nightly" >> $GITHUB_OUTPUT
-  
   package:
     permissions:
       contents: read
       packages: write
-    uses: 'flowforge/github-actions-workflows/.github/workflows/publish_node_package.yml@feat-npm-publish-workflow'
+    uses: 'flowforge/github-actions-workflows/.github/workflows/publish_node_package.yml@feat-npm-publish-outputs'
     with:
-      # release_name: ${{ needs.prepare.outputs.release_name}}
       package_name: flowforge-driver-localfs
       package_dependencies: |
         @flowforge/nr-launcher
-        
+  
+  debug:
+    runs-on: ubuntu-latest
+    needs: package
+    steps:
+      - name: Print release name
+        run: echo ${{ needs.package.outputs.release_name }}
+
   dispatch:
     runs-on: ubuntu-latest
+    needs: package
     if: false
     steps:
       - name: Generate a token
@@ -57,4 +55,4 @@ jobs:
           repo: flowforge/flowforge
           ref: feat-publish-pipeline-poc
           token: ${{ steps.generate_token.outputs.token }}
-          inputs: '{"localfs_ref": "${{ github.ref }}", "localfs_release_name": "${{ env.release_name }}"}'
+          inputs: '{"localfs_ref": "${{ github.ref }}", "localfs_release_name": "${{ needs.package.outputs.release_name }}"}'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,9 @@ on:
         description: 'flowforge-nr-launcher package version'
         required: false
         default: 'nightly'
+      nr_launcher_ref:
+        description: 'flowforge-nr-launcher package ref'
+        required: false
   schedule:
     - cron: '0 23 * * *'
   push:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: package
     steps:
-      - name: Print release name
+      - name: Print release name from package job
         run: echo ${{ needs.package.outputs.release_name }}
 
   dispatch:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,27 +18,33 @@ on:
 
 
 jobs:
-  prepare:
+  # prepare:
+  #   runs-on: ubuntu-latest
+  #   outputs:
+  #     release_name: ${{ steps.set_release.outputs.release_name }}
+  #   steps:
+  #     - name: Set nigthly release
+  #       id: set_release
+  #       # if: ${{ github.event_name == 'schedule' }}
+  #       run: echo "release_name=nightly" >> $GITHUB_OUTPUT
+  
+  publish:
+    # needs: prepare
     runs-on: ubuntu-latest
-    outputs:
-      release_name: ${{ steps.set_release.outputs.release_name }}
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Set nigthly release
         id: set_release
         # if: ${{ github.event_name == 'schedule' }}
         run: echo "release_name=nightly" >> $GITHUB_OUTPUT
-  
-  publish:
-    needs: prepare
-    permissions:
-      contents: read
-      packages: write
-    uses: 'flowforge/github-actions-workflows/.github/workflows/publish_node_package.yml@feat-npm-publish-workflow'
-    with:
-      release_name: ${{ needs.prepare.outputs.release_name}}
-      package_name: flowforge-driver-localfs
-      package_dependencies: |
-        @flowforge/nr-launcher
+      - uses: 'flowforge/github-actions-workflows/.github/workflows/publish_node_package.yml@feat-npm-publish-workflow'
+        with:
+          release_name: ${{ needs.prepare.outputs.release_name}}
+          package_name: flowforge-driver-localfs
+          package_dependencies: |
+            @flowforge/nr-launcher
         
   dispatch:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ on:
     - cron: '0 23 * * *'
   push:
     branches:
-      - 'feature/*' 
+      - 'feat-' 
 
 jobs:
   publish:
@@ -23,18 +23,10 @@ jobs:
           npm version prerelease --preid `git rev-parse --short HEAD`-`date +%Y%m%d` --no-git-tag-version
           cat package.json | jq '.dependencies["@flowforge/nr-launcher"] = "${{ env.release_name }}"' > package.json-patched
           mv package.json-patched package.json
-      - name: "Publish flowforge-nr-launcher"
+      - name: "publish flowforge-driver-localfs"
         uses: JS-DevTools/npm-publish@v2
         with:
           tag: ${{ env.release_name }}
           package: ./package.json
-          registry: https://npm.pkg.github.com
-          token: ${{ secrets.GITHUB_TOKEN }}  
-      - name: "Publish flowforge-nr-theme"
-        uses: JS-DevTools/npm-publish@v2
-        with:
-          tag: ${{ env.release_name }}
-          package: ./lib/theme/package.json
-          ignore-scripts: false
           registry: https://npm.pkg.github.com
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,6 +32,7 @@ jobs:
     uses: 'flowforge/github-actions-workflows/.github/workflows/publish_node_package.yml@main'
     with:
       package_name: flowforge-driver-localfs
+      publish_package: true\
       package_dependencies: |
         @flowforge/nr-launcher
 


### PR DESCRIPTION
## Description

Introduce package publish pipeline.
At this moment this is a simple pipeline which will build and publish package in '_nightly_' version to private NPM registry. 

## Related Issue(s)

Generic automation improvements.

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

