### PR TITLE
Enable flowforge package build dispatcher after package publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
     needs: build
     if: |
       ( github.event_name == 'push' && github.ref == 'refs/heads/main' ) ||
-      github.event_name == 'workflow_dispatch' ||
+      ( github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' ) ||
       github.event_name == 'schedule'
     uses: 'flowforge/github-actions-workflows/.github/workflows/publish_node_package.yml@main'
     with:
@@ -36,7 +36,8 @@ jobs:
       package_dependencies: |
         @flowforge/nr-launcher
 
-  dispatch_flowforge_build:
+  dispatch:
+    name: Dispatch flowforge package build
     runs-on: ubuntu-latest
     needs: publish
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,9 +26,9 @@ jobs:
 
   publish:
     needs: build
-    if: |
-      ( github.event_name == 'push' && github.ref == 'refs/heads/main' ) ||
-      github.event_name == 'schedule'
+    # if: |
+    #   ( github.event_name == 'push' && github.ref == 'refs/heads/main' ) ||
+    #   github.event_name == 'schedule'
     uses: 'flowforge/github-actions-workflows/.github/workflows/publish_node_package.yml@main'
     with:
       package_name: flowforge-driver-localfs

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,7 @@ jobs:
     needs: build
     if: |
       ( github.event_name == 'push' && github.ref == 'refs/heads/main' ) ||
+      ( github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' ) ||
       github.event_name == 'schedule'
     uses: 'flowforge/github-actions-workflows/.github/workflows/publish_node_package.yml@main'
     with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
     needs: build
     if: |
       ( github.event_name == 'push' && github.ref == 'refs/heads/main' ) ||
-      ( github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' ) ||
+      github.event_name == 'workflow_dispatch' ||
       github.event_name == 'schedule'
     uses: 'flowforge/github-actions-workflows/.github/workflows/publish_node_package.yml@main'
     with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,4 @@
 name: Build and push package
-
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,10 +36,9 @@ jobs:
       package_dependencies: |
         @flowforge/nr-launcher
 
-  dispatch:
+  dispatch_flowforge_build:
     runs-on: ubuntu-latest
     needs: publish
-    if: false
     steps:
       - name: Generate a token
         id: generate_token
@@ -48,12 +47,12 @@ jobs:
           app_id: ${{ secrets.GH_BOT_APP_ID }}
           private_key: ${{ secrets.GH_BOT_APP_KEY }}
 
-      - name: Trigger flowforge package rebuild
+      - name: Trigger flowforge package build
         uses: benc-uk/workflow-dispatch@v1
         with:
           workflow: publish.yml
           repo: flowforge/flowforge
-          ref: feat-publish-pipeline-poc
+          ref: main
           token: ${{ steps.generate_token.outputs.token }}
           inputs: '{"localfs_ref": "${{ github.ref }}", "localfs_release_name": "${{ needs.package.outputs.release_name }}"}'
           

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,9 +25,9 @@ jobs:
 
   publish:
     needs: build
-    # if: |
-    #   ( github.event_name == 'push' && github.ref == 'refs/heads/main' ) ||
-    #   github.event_name == 'schedule'
+    if: |
+      ( github.event_name == 'push' && github.ref == 'refs/heads/main' ) ||
+      github.event_name == 'schedule'
     uses: 'flowforge/github-actions-workflows/.github/workflows/publish_node_package.yml@main'
     with:
       package_name: flowforge-driver-localfs


### PR DESCRIPTION
## Description

Enable flowforge package build dispatcher after package publish.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

